### PR TITLE
require node >= 0.10.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "react-hot-loader": "1.2.1",
     "webpack": "1.7.2",
     "webpack-dev-server": "1.7.0"
+  },
+  "engines": {
+    "node" : ">=0.10.32"
   }
 }


### PR DESCRIPTION
Since we've seen in https://github.com/RickWong/react-isomorphic-starterkit/issues/11 that at least node 0.10.32, we should require it
