### PR TITLE
show how to reference the api exposed by the server

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -7,7 +7,11 @@ import routes from "views/Routes";
  * Fire-up React Router.
  */
 Router.run(routes, Router.HistoryLocation, (Handler) => {
-	Transmit.render(Handler, {}, document.getElementById("react-root"));
+	Transmit.render(Handler, {
+		queryParams: {
+			origin: window.location.origin
+		}
+    }, document.getElementById("react-root"));
 });
 
 /**

--- a/src/views/Main.js
+++ b/src/views/Main.js
@@ -146,7 +146,7 @@ export default Transmit.createContainer(Main, {
 		 */
 		allStargazers (queryParams) {
 			return fetch(
-				"https://api.github.com/repos/RickWong/react-isomorphic-starterkit/stargazers" +
+				queryParams.origin + "/api/github/repos/RickWong/react-isomorphic-starterkit/stargazers" +
 				`?per_page=100&page=${queryParams.nextPage}`
 			).then((response) => response.json()).then((body) => {
 				/**


### PR DESCRIPTION
I found it much harder to actually use my own api than an external one, so I updated this to illustrate how to accomplish this.

might make more sense to create a wrapper around fetch that does this automatically (so that you can use relative urls on the server side like you can on the front end), or even create a specific api fetch function.

thoughts?
