### PR TITLE
Allow other hosts to access webpack server

### DIFF
--- a/webpack.client-watch.js
+++ b/webpack.client-watch.js
@@ -36,7 +36,8 @@ config.devServer = {
 	quiet:       true,
 	noInfo:      false,
 	headers:     {"Access-Control-Allow-Origin": "*"},
-	stats:       {colors: true}
+	stats:       {colors: true},
+	host:        "0.0.0.0"
 };
 
 module.exports = config;


### PR DESCRIPTION
Without this, it is difficult to test across networks, across devices, and between VMs.
