### PR TITLE
babel-plugin-typecheck dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "babel": "5.4.7",
+    "babel-plugin-typecheck": "0.0.3",
     "hapi": "8.6.0",
     "piping": "0.1.8",
     "react": "0.13.3",
@@ -37,7 +38,6 @@
   "devDependencies": {
     "babel-core": "5.4.7",
     "babel-loader": "5.1.3",
-    "babel-plugin-typecheck": "0.0.3",
     "babel-runtime": "5.4.7",
     "concurrently": "0.1.1",
     "json-loader": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
     "babel": "5.4.7",
     "babel-plugin-typecheck": "0.0.3",
     "hapi": "8.6.0",
+    "isomorphic-fetch": "2.1.0",
     "piping": "0.1.8",
     "react": "0.13.3",
     "react-inline-css": "1.1.1",
     "react-router": "0.13.3",
-    "react-transmit": "2.6.3",
-    "isomorphic-fetch": "2.1.0"
+    "react-transmit": "2.6.3"
   },
   "devDependencies": {
     "babel-core": "5.4.7",


### PR DESCRIPTION
Hey @RickWong - sorry if this PR is unnecessary but I think `babel-plugin-typecheck` should live in dependencies since it's required [here](https://github.com/RickWong/react-isomorphic-starterkit/blob/master/babel.server.js#L3)
