### PR TITLE
Updated babel-core dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-transmit": "2.6.3"
   },
   "devDependencies": {
-    "babel-core": "5.7.4",
+    "babel-core": "^5.8.20",
     "babel-loader": "5.3.2",
     "babel-runtime": "5.7.0",
     "concurrently": "0.1.1",


### PR DESCRIPTION
This fixes the build error on a fresh install: 

```
ERROR in ./src/client.js
[0] Module build failed: Error: ~/react-isomorphic-starterkit/src/client.js: attachComments needs range information
[0]     at Object.attachComments (~/react-isomorphic-starterkit/node_modules/babel-core/node_modules/estraverse/estraverse.js:741:19)
[0]     at Object.exports.default (~/react-isomorphic-starterkit/node_modules/babel-core/lib/helpers/parse.js:80:27)
[0]     at File.parse (~/react-isomorphic-starterkit/node_modules/babel-core/lib/transformation/file/index.js:549:40)
[0]     at File.parseCode (~/react-isomorphic-starterkit/node_modules/babel-core/lib/transformation/file/index.js:658:20)
[0]     at ~/react-isomorphic-starterkit/node_modules/babel-core/lib/transformation/pipeline.js:167:12
[0]     at File.wrap (~/react-isomorphic-starterkit/node_modules/babel-core/lib/transformation/file/index.js:614:16)
[0]     at Pipeline.transform (~/react-isomorphic-starterkit/node_modules/babel-core/lib/transformation/pipeline.js:165:17)
[0]     at transpile (~/react-isomorphic-starterkit/node_modules/babel-loader/index.js:12:22)
[0]     at Object.module.exports (~/react-isomorphic-starterkit/node_modules/babel-loader/index.js:69:12)
[0]  @ multi main
```
