### PR TITLE
Support Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "babel.server.js",
   "scripts": {
-    "start": "NODE_PATH=\"./src\" node --harmony ./babel.server",
+    "start": "node --harmony ./babel.server",
     "build": "node ./node_modules/webpack/bin/webpack.js --verbose --colors --display-error-details --config webpack.client.js",
     "watch": "npm run start"
   },

--- a/src/client.js
+++ b/src/client.js
@@ -2,8 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom";
 import {Router} from "react-router";
 import Transmit from "react-transmit";
-import routes from "views/routes";
 import {createHistory} from "history";
+
+import routes from "./views/routes";
 
 /**
  * Fire-up React Router.

--- a/src/server.js
+++ b/src/server.js
@@ -8,8 +8,8 @@ import {RoutingContext, match} from "react-router";
 import {createLocation} from "history";
 import Transmit from "react-transmit";
 
-import githubApi from "apis/github";
-import routes from "views/routes";
+import githubApi from "./apis/github";
+import routes from "./views/routes";
 
 try {
 	const app      = koa();

--- a/src/views/Main.js
+++ b/src/views/Main.js
@@ -1,7 +1,8 @@
 import React from "react";
 import InlineCss from "react-inline-css";
 import Transmit from "react-transmit";
-import githubApi from "apis/github";
+
+import githubApi from "../apis/github";
 
 const fetchStargazers  = (page, per_page = 100) => {
 	return githubApi.browse(

--- a/src/views/routes.js
+++ b/src/views/routes.js
@@ -1,6 +1,7 @@
-import Main from "views/Main";
 import React from "react";
 import {Router, Route} from "react-router";
+
+import Main from "./Main";
 
 /**
  * The React Router 1.0 routes for both the server and the client.


### PR DESCRIPTION
- Don't attempt to set environment variable `NODE_PATH`
- Modified import paths to be current-script-relative

See issue #88 
