### PR TITLE
Stop bundling react in the server package

### DIFF
--- a/configs/webpack.server.js
+++ b/configs/webpack.server.js
@@ -11,6 +11,23 @@ fs.readdirSync('node_modules')
 	.forEach(function (mod) {
 		nodeModules[mod] = 'commonjs ' + mod;
 	});
+var nodeModulesTransform = function(context, request, callback) {
+  // search for a '/' indicating a nested module
+  var slashIndex = request.indexOf("/");
+  var rootModuleName;
+  if (slashIndex == -1) {
+    rootModuleName = request;
+  } else {
+    rootModuleName = request.substr(0, slashIndex);
+  }
+
+  // Match for root modules that are in our node_modules
+  if (nodeModules.hasOwnProperty(rootModuleName)) {
+    callback(null, "commonjs " + request);
+  } else {
+    callback();
+  }
+}
 
 module.exports = {
 	target:  "node",
@@ -36,7 +53,7 @@ module.exports = {
 		],
 		noParse: /\.min\.js/
 	},
-	externals: nodeModules,
+	externals: nodeModulesTransform,
 	resolve: {
 		modulesDirectories: [
 			"src",


### PR DESCRIPTION
Because of a bug in the "exclude" part of the webpack config, most of react is being unnecessarily bundled into the server.js bundle instead of being imported as it should be. Fixing this reduces the server.js file from 635kb -> 19.2kb, and almost halves the build time. 

Before change:

```
[0] Hash: 49a3f3fc7a267a050755
[0] Version: webpack 1.12.11
[0] Time: 8685ms
[0]         Asset    Size  Chunks             Chunk Names
[0]     server.js  635 kB       0  [emitted]  main
[0] server.js.map  756 kB       0  [emitted]  main
[0]    [0] multi main 28 bytes {0} [built]
[0]     + 160 hidden modules
```

After change:

```
[0] Hash: 1e337ff3b0337ab81127
[0] Version: webpack 1.12.11
[0] Time: 5516ms
[0]         Asset     Size  Chunks             Chunk Names
[0]     server.js  19.2 kB       0  [emitted]  main
[0] server.js.map  19.1 kB       0  [emitted]  main
[0]    [0] multi main 28 bytes {0} [built]
[0]     + 18 hidden modules
```

Can read about this in my comment here:
https://github.com/webpack/webpack/issues/839#issuecomment-177219660
