### PR TITLE
Add ability to be used as a Yeoman generator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,0 +1,34 @@
+'use strict';
+var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
+var yosay = require('yosay');
+var path = require('path');
+
+var sourcePath = path.join(__dirname, '../..');
+
+module.exports = yeoman.Base.extend({
+  paths: function() {
+    this.sourceRoot(sourcePath);
+  },
+
+  prompting: function () {
+    this.log(yosay(
+      'Welcome to the dandy ' + chalk.red('React Isomorphic Starterkit') + ' generator!'
+    ));
+  },
+
+  writing: function () {
+    this.fs.copy(this.templatePath('configs'), this.destinationPath('configs'));
+    this.fs.copy(this.templatePath('dist'), this.destinationPath('dist'));
+    this.fs.copy(this.templatePath('src'), this.destinationPath('src'));
+    this.fs.copy(this.templatePath('static'), this.destinationPath('static'));
+    this.fs.copy(this.templatePath('.gitignore'), this.destinationPath('.gitignore'));
+    this.fs.copy(this.templatePath('package.json'), this.destinationPath('package.json'));
+    this.fs.copy(this.templatePath('LICENSE.md'), this.destinationPath('LICENSE.md'));
+    this.fs.copy(this.templatePath('README.md'), this.destinationPath('README.md'));
+  },
+
+  install: function () {
+    this.npmInstall();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-isomorphic-starterkit",
+  "name": "generator-react-isomorphic-starterkit",
   "description": "Isomorphic starterkit with server-side React rendering.",
   "version": "5.1.3",
   "license": "BSD-3-Clause",
@@ -17,7 +17,8 @@
     "template",
     "webpack",
     "koa",
-    "transmit"
+    "transmit",
+    "yeoman-generator"
   ],
   "main": "dist/server.js",
   "scripts": {
@@ -59,7 +60,9 @@
     "json-loader": "0.5.4",
     "just-wait": "1.0.3",
     "webpack": "1.12.11",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.14.1",
+    "yeoman-generator": "^0.22.5",
+    "yosay": "^1.1.0"
   },
   "engines": {
     "node": ">=0.10.32"


### PR DESCRIPTION
Enables use of the project as a Yeoman generator.  Tries to leave the project structure as close to the original as possible.

My suggestion, though, would be to release version `6.0.0` that is not backward compatible with the current structure, and go all in on Yeoman.  You may not want to make that big of a change, but cloning a starter kit and changing it is kind of a weird pattern and the current setup doesn't really allow people to make changes to their configuration, which is something that Yeoman would allow you to configure on installation, which would be pretty sweet.  If you were interested in that kind of more-drastic change, I would be happy to add to this PR to make that happen.

The major change, if you were to do that, would be moving the current root of the project under either `app/` or `generators/app` (depends on your preferences).  That's really all that _has_ to change, although you could start to build up features that are provided by the user at installation time (like setting the name of the project in the `package.json` dynamically).
### Changes
- Tweaked the `package.json` file to provide the requirements for the Yeoman
- Added a default "app" generator that copies over the required files to the new destination and runs the dependency installation
### Testing the Generator
- Install [`yeoman`](http://yeoman.io)
- Pull this PR locally and install the dependencies
- Run `npm link` in the repo, which will add it to the list of generators available to `yeoman`
- Run `yo` in the directory that you want to create a new project, and choose the option for `React Isomorphic Starterkit`

---

Closes #2 
