### PR TITLE
use webpack-node-externals to exclude node modules

### DIFF
--- a/configs/webpack.server.js
+++ b/configs/webpack.server.js
@@ -1,16 +1,7 @@
 var webpack = require("webpack");
+var nodeExternals = require('webpack-node-externals');
 var path = require("path");
 var fs = require('fs');
-
-var nodeModules = {};
-
-fs.readdirSync('node_modules')
-	.filter(function (x) {
-		return ['.bin'].indexOf(x) === -1;
-	})
-	.forEach(function (mod) {
-		nodeModules[mod] = 'commonjs ' + mod;
-	});
 
 module.exports = {
 	target:  "node",
@@ -36,7 +27,9 @@ module.exports = {
 		],
 		noParse: /\.min\.js/
 	},
-	externals: nodeModules,
+	externals: [nodeExternals({
+		whitelist: ["webpack/hot/poll?1000"]
+	})],
 	resolve: {
 		modulesDirectories: [
 			"src",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "json-loader": "0.5.4",
     "just-wait": "1.0.3",
     "webpack": "1.12.11",
-    "webpack-dev-server": "1.14.1"
+    "webpack-dev-server": "1.14.1",
+    "webpack-node-externals": "^0.4.1"
   },
   "engines": {
     "node": ">=0.10.32"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "just-wait": "1.0.3",
     "webpack": "1.12.11",
     "webpack-dev-server": "1.14.1",
-    "webpack-node-externals": "^0.4.1"
+    "webpack-node-externals": "0.4.1"
   },
   "engines": {
     "node": ">=0.10.32"


### PR DESCRIPTION
Use [webpack-node-modules](https://github.com/liady/webpack-node-externals) to extract node modules from server bundling.
Closes #104
