### PR TITLE
Bug Fix: Cant find preset es2015 error

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "stage-0", "react"]
+}


### PR DESCRIPTION
`Couldn't find preset "es2015" relative to directory`.  I was getting this error when I ran `npm run watch`.  I noticed that project did not have the babel config file so I added it.  It resolved the issue.
