### PR TITLE
Dropped isomorphic-fetch in favor of cross-fetch (React Native compatible).

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   },
   "dependencies": {
     "babel-polyfill": "6.6.1",
+    "cross-fetch": "1.1.0",
     "css-loader": "0.23.1",
     "fetch-plus": "3.8.1",
     "fetch-plus-bearerauth": "3.5.0",
     "fetch-plus-json": "3.6.0",
     "file-loader": "0.8.5",
-    "isomorphic-fetch": "2.2.1",
     "isomorphic-style-loader": "0.0.10",
     "koa": "1.2.0",
     "koa-proxy": "0.5.0",

--- a/src/apis/github.js
+++ b/src/apis/github.js
@@ -1,4 +1,4 @@
-import fetch from "isomorphic-fetch";
+import fetch from "cross-fetch";
 import fetchPlus from "fetch-plus";
 import plusJson from "fetch-plus-json";
 import plusBearerauth from "fetch-plus-bearerauth";


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and [fixed](https://github.com/matthew-andrews/isomorphic-fetch/issues/125) alternative to the community.